### PR TITLE
v2.0.0 and support for sessionStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,57 @@
 # superstore-sync [![Build Status](https://travis-ci.org/matthew-andrews/superstore-sync.png?branch=master)](https://travis-ci.org/matthew-andrews/superstore-sync) [![NPM version](https://badge.fury.io/js/superstore-sync.png)](http://badge.fury.io/js/superstore-sync)
 
-Superstore is a simple lightweight synchronous wrapper around localStorage.  Its features include:
+Superstore is a simple lightweight synchronous wrapper around the Web Storage APIs [localStorage](https://developer.mozilla.org/en/docs/Web/API/Window/localStorage) and [sessionStorage](https://developer.mozilla.org/en/docs/Web/API/Window/sessionStorage).  Its features include:
 
 - It is [resilient to iOS's strange behaviour in private browsing mode](http://stackoverflow.com/questions/14555347/html5-localstorage-doesnt-works-in-ios-safari-private-browsing).
 - It accepts objects as values and runs `JSON.stringify` on **#set** and `JSON.parse` on **#get** for you.
+
+If you require an asyncronous version please use [superstore](https://github.com/matthew-andrews/superstore) instead.
+
+## install
+### NPM
+```
+npm install superstore-sync --save
+```
+
+### bower
+```
+bower install superstore-sync --save
+```
 
 ## api
 
 superstore-sync is an uninstantiable module.  Its methods are:
 
-### #get(key)
+## local
 
-### #set(key, value)
+### #local.get(key)
 
-### #unset(key)
+### #local.set(key, value)
 
-### #clear(prefix)
+### #local.unset(key)
+
+### #local.clear(prefix)
+
+## session
+
+### #session.get(key)
+
+### #session.set(key, value)
+
+### #session.unset(key)
+
+### #session.clear(prefix)
+
+## usage
+```javascript
+var store = require('superstore-sync');
+
+//Persist a value to local storage
+var value = store.local.set('foo', 'bar');
+
+//Get a value from session storage
+var session = store.session.get('baz');
+```
 
 ## todo
 

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,22 @@
+{
+  "name": "superstore-sync",
+  "version": "2.0.0",
+  "homepage": "https://github.com/matthew-andrews/superstore-sync",
+  "authors": [
+    "Matthew Andrews <matt@mattandre.ws>"
+  ],
+  "description": "Web Storeage APIs without the bugs.",
+  "main": "lib/superstore-sync.js",
+  "keywords": [
+    "localstorage",
+    "sessionstorage"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}

--- a/lib/superstore-sync.js
+++ b/lib/superstore-sync.js
@@ -5,7 +5,9 @@
  * @copyright The Financial Times [All Rights Reserved]
  */
 
-var escapeRegex = require('escape-regexp-component');
+var escapeRegex = function(str){
+  return String(str).replace(/([.*+?=^!:${}()|[\]\/\\])/g, '\\$1');
+};
 
 var keys = {};
 var store = {};
@@ -19,6 +21,10 @@ window.addEventListener("storage", function(e) {
   }
 });
 
+function Superstore(type) {
+	this.storage = window[type];
+}
+
 /**
  * get localstorage value for key falling back to in memory for iOS private browsing bug
  * <http://stackoverflow.com/questions/9077101/iphone-localstorage-quota-exceeded-err-issue>
@@ -26,14 +32,14 @@ window.addEventListener("storage", function(e) {
  * @return {*} data for supplied key
  *
  */
-exports.get = function(key) {
+Superstore.prototype.get = function(key) {
   if (arguments.length !== 1) {
     throw Error("get expects 1 argument, " + arguments.length + " given; " + key);
   }
   if (!keys[key] && persist) {
     var data;
     try {
-      data = localStorage[key];
+      data = this.storage[key];
     } catch(e) {
       persist = false; // Safari 8 with Cookies set to 'Never' throws on every read
     }
@@ -55,13 +61,13 @@ exports.get = function(key) {
  * @return {*} value
  *
  */
-exports.set = function(key, value) {
+Superstore.prototype.set = function(key, value) {
   if (arguments.length !== 2) {
     throw Error("set expects 2 arguments, " + arguments.length + " given; " + key);
   }
   if (persist) {
     try {
-      localStorage[key] = JSON.stringify(value);
+      this.storage[key] = JSON.stringify(value);
     } catch(err) {
 
       // Known iOS Private Browsing Bug - fall back to non-persistent storage
@@ -83,10 +89,10 @@ exports.set = function(key, value) {
  * unset value in store for key
  * @param {String} key
  */
-exports.unset = function(key) {
+Superstore.prototype.unset = function(key) {
   delete store[key];
   delete keys[key];
-  localStorage.removeItem(key);
+  this.storage.removeItem(key);
 };
 
 /**
@@ -95,10 +101,10 @@ exports.unset = function(key) {
  * #clear(true) and #clear() clear cache and persistent layer, #clear(false) only clears cache
  *
  */
-exports.clear = function(clearPrefix) {
+Superstore.prototype.clear = function(clearPrefix) {
   if (!clearPrefix) {
     if (persist) {
-      localStorage.clear();
+      this.storage.clear();
     }
     store = {};
     keys = {};
@@ -113,3 +119,6 @@ exports.clear = function(clearPrefix) {
     }
   }
 };
+
+module.exports.local = new Superstore('localStorage');
+module.exports.session = new Superstore('sessionStorage');

--- a/package.json
+++ b/package.json
@@ -27,10 +27,8 @@
     "url": "git@github.com:matthew-andrews/superstore-sync.git"
   },
   "keywords": [
-    "localstorage"
+    "localstorage",
+	"sessionstorage"
   ],
-  "license": "MIT",
-  "dependencies": {
-    "escape-regexp-component": "~1.0"
-  }
+  "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superstore-sync",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Local storage, without the bugs.",
   "main": "lib/superstore-sync.js",
   "engines": {
@@ -28,7 +28,7 @@
   },
   "keywords": [
     "localstorage",
-	"sessionstorage"
+    "sessionstorage"
   ],
   "license": "MIT"
 }

--- a/test/tests/superstore-sync.test.js
+++ b/test/tests/superstore-sync.test.js
@@ -12,11 +12,11 @@ try {
 
 function getLocalStorage(key) {
   return localStorage[key];
-};
+}
 
 function setLocalStorage(key, val) {
   if (buggyLocalStorage) return localStorage[key] = val;
-};
+}
 
 tests["setUp"] = function() {
   localStorage.clear();
@@ -25,7 +25,7 @@ tests["setUp"] = function() {
 tests["Removing a key before it's set should be harmless"] = function() {
   var exceptionThrown = false;
   try {
-    superstoreSync.unset('keyUnset');
+    superstoreSync.local.unset('keyUnset');
   } catch (e) {
     exceptionThrown = true;
   }
@@ -34,28 +34,28 @@ tests["Removing a key before it's set should be harmless"] = function() {
 };
 
 tests["Should be able to set and get data against a key"] = function() {
-  superstoreSync.set('keyOne', 'value1');
-  var val = superstoreSync.get('keyOne');
+  superstoreSync.local.set('keyOne', 'value1');
+  var val = superstoreSync.local.get('keyOne');
   assert.equals('value1', val);
 };
 
 tests[prefix + "Should be able to read things (twice) from local storage"] = function() {
-  superstoreSync.set("keyTwo", 3884);
+  superstoreSync.local.set("keyTwo", 3884);
 
-  var val = superstoreSync.get('keyTwo');
+  var val = superstoreSync.local.get('keyTwo');
   assert.equals(3884, val);
-  var val2 = superstoreSync.get('keyTwo');
+  var val2 = superstoreSync.local.get('keyTwo');
   assert.equals(3884, val2);
 };
 
 tests[prefix + "Should be able to unset things"] = function() {
   setLocalStorage("keyThree", "Hello");
-  var val = superstoreSync.unset('keyThree');
+  var val = superstoreSync.local.unset('keyThree');
   assert.equals(undefined, getLocalStorage("keyThree"));
 };
 
 tests["Getting an unset key should return a nully value"] = function() {
-  var val = superstoreSync.get("keySixth");
+  var val = superstoreSync.local.get("keySixth");
   assert.equals(val, undefined);
 };
 
@@ -63,19 +63,19 @@ tests[prefix + "Should json encode and decode objects"] = function() {
   var obj = {
     test: [1,4,6,7]
   };
-  superstoreSync.set('keySeventh', obj);
+  superstoreSync.local.set('keySeventh', obj);
   assert.equals(JSON.stringify(obj), getLocalStorage("keySeventh"));
 };
 
 tests["#clear(something) clears only our namespaced data"] = function() {
-  superstoreSync.set('other', '123');
-  superstoreSync.set('pref.?xKeyTenth', 'A');
-  superstoreSync.set('pref.?xKeyEleventh', 'B');
-  superstoreSync.clear('pref.?xKey');
+  superstoreSync.local.set('other', '123');
+  superstoreSync.local.set('pref.?xKeyTenth', 'A');
+  superstoreSync.local.set('pref.?xKeyEleventh', 'B');
+  superstoreSync.local.clear('pref.?xKey');
 
-  assert.equals(undefined, superstoreSync.get("pref.?xKeyTenth"));
-  assert.equals(undefined, superstoreSync.get("pref.?xKeyEleventh"));
-  assert.equals('123', superstoreSync.get("other"));
+  assert.equals(undefined, superstoreSync.local.get("pref.?xKeyTenth"));
+  assert.equals(undefined, superstoreSync.local.get("pref.?xKeyEleventh"));
+  assert.equals('123', superstoreSync.local.get("other"));
 
   if (!buggyLocalStorage) {
     assert.equals(undefined, getLocalStorage("pref.?xKeyEleventh"));
@@ -85,12 +85,12 @@ tests["#clear(something) clears only our namespaced data"] = function() {
 };
 
 tests["#clear() clears all data"] = function() {
-  superstoreSync.set('other', '123');
-  superstoreSync.set('prefixKeyTwelth', 'C');
-  superstoreSync.clear();
+  superstoreSync.local.set('other', '123');
+  superstoreSync.local.set('prefixKeyTwelth', 'C');
+  superstoreSync.local.clear();
 
-  assert.equals(undefined, superstoreSync.get("prefixKeyTwelth"));
-  assert.equals(undefined, superstoreSync.get("other"));
+  assert.equals(undefined, superstoreSync.local.get("prefixKeyTwelth"));
+  assert.equals(undefined, superstoreSync.local.get("other"));
 
   if (!buggyLocalStorage) {
     assert.equals(undefined, getLocalStorage("prefixKeyTwelth"));
@@ -99,14 +99,14 @@ tests["#clear() clears all data"] = function() {
 };
 
 tests["watch for changes in other processes"] = function() {
-  superstoreSync.set('key13', 'A');
+  superstoreSync.local.set('key13', 'A');
 
   var event = new CustomEvent("storage");
   event.key = "key13";
   event.newValue = "\"B\"";
   window.dispatchEvent(event);
 
-  var val = superstoreSync.get('key13');
+  var val = superstoreSync.local.get('key13');
   assert.equals(val, 'B');
 };
 


### PR DESCRIPTION
This introduces a breaking change to the API. The API exposes access to both local and session storage interfaces. Suggested:

```javascript
var store = require('superstore-sync').local;

store.get('foo');
```

I have also included a bower.json manifest so that we can publish to the registry and in ture enable [superstore](https://github.com/matthew-andrews/superstore) to use as bower dep.

/cc @matthew-andrews 