### PR TITLE
Keep separate storage objects for each instance of superstore

### DIFF
--- a/lib/superstore-sync.js
+++ b/lib/superstore-sync.js
@@ -20,7 +20,7 @@ function Superstore(type) {
 	this.storage = window[type];
   this.keys = {};
   this.store = {};
-
+  // TODO: check the storageArea so that we only refresh the key when we need to
   window.addEventListener("storage", function(e) {
     if (this.keys[e.key]) {
       this.keys[e.key] = true;

--- a/lib/superstore-sync.js
+++ b/lib/superstore-sync.js
@@ -14,15 +14,19 @@ var store = {};
 var persist = true;
 
 // Watch for changes from other tabs
-window.addEventListener("storage", function(e) {
-  if (keys[e.key]) {
-    keys[e.key] = true;
-    store[e.key] = JSON.parse(e.newValue);
-  }
-});
+
 
 function Superstore(type) {
 	this.storage = window[type];
+  this.keys = {};
+  this.store = {};
+
+  window.addEventListener("storage", function(e) {
+    if (this.keys[e.key]) {
+      this.keys[e.key] = true;
+      this.store[e.key] = JSON.parse(e.newValue);
+    }
+  }.bind(this));
 }
 
 /**
@@ -36,7 +40,7 @@ Superstore.prototype.get = function(key) {
   if (arguments.length !== 1) {
     throw Error("get expects 1 argument, " + arguments.length + " given; " + key);
   }
-  if (!keys[key] && persist) {
+  if (!this.keys[key] && persist) {
     var data;
     try {
       data = this.storage[key];
@@ -47,10 +51,10 @@ Superstore.prototype.get = function(key) {
     // Slightly weird hack because JSON.parse of an undefined value throws
     // a weird exception "SyntaxError: Unexpected token u"
     if (data) data = JSON.parse(data);
-    store[key] = data;
-    keys[key] = true;
+    this.store[key] = data;
+    this.keys[key] = true;
   }
-  return store[key];
+  return this.store[key];
 };
 
 /**
@@ -79,8 +83,8 @@ Superstore.prototype.set = function(key, value) {
     }
   }
 
-  store[key] = value;
-  keys[key] = true;
+  this.store[key] = value;
+  this.keys[key] = true;
   return value;
 };
 
@@ -90,8 +94,8 @@ Superstore.prototype.set = function(key, value) {
  * @param {String} key
  */
 Superstore.prototype.unset = function(key) {
-  delete store[key];
-  delete keys[key];
+  delete this.store[key];
+  delete this.keys[key];
   this.storage.removeItem(key);
 };
 
@@ -106,14 +110,14 @@ Superstore.prototype.clear = function(clearPrefix) {
     if (persist) {
       this.storage.clear();
     }
-    store = {};
-    keys = {};
+    this.store = {};
+    this.keys = {};
     return;
   }
 
   clearPrefix = escapeRegex(clearPrefix);
   var clearKeyRegex = new RegExp("^" + clearPrefix);
-  for (var key in keys) {
+  for (var key in this.keys) {
     if (key.match(clearKeyRegex)) {
       this.unset(key);
     }

--- a/test/tests/superstore-sync.test.js
+++ b/test/tests/superstore-sync.test.js
@@ -39,6 +39,15 @@ tests["Should be able to set and get data against a key"] = function() {
   assert.equals('value1', val);
 };
 
+tests["Should be able to use the same key for local and session storage"] = function() {
+  superstoreSync.local.set('keyOne', 'localValue');
+  superstoreSync.session.set('keyOne', 'sessionValue');
+  var localVal = superstoreSync.local.get('keyOne');
+  var sessionVal = superstoreSync.session.get('keyOne');
+  assert.equals('localValue', localVal);
+  assert.equals('sessionValue', sessionVal);
+};
+
 tests[prefix + "Should be able to read things (twice) from local storage"] = function() {
   superstoreSync.local.set("keyTwo", 3884);
 


### PR DESCRIPTION
/cc @matthew-andrews 
Fixes bug when using the same key name for local and session storage